### PR TITLE
Implement domain models and Cosmos schema

### DIFF
--- a/infra/cosmos-schema.json
+++ b/infra/cosmos-schema.json
@@ -1,0 +1,21 @@
+{
+  "database": "astroform-db",
+  "containers": [
+    {
+      "name": "Users",
+      "partitionKey": "/id"
+    },
+    {
+      "name": "Forms",
+      "partitionKey": "/userId"
+    },
+    {
+      "name": "FormSubmissions",
+      "partitionKey": "/formId"
+    },
+    {
+      "name": "ActivityLogs",
+      "partitionKey": "/partitionKey"
+    }
+  ]
+}

--- a/infra/modules/cosmos.bicep
+++ b/infra/modules/cosmos.bicep
@@ -1,7 +1,8 @@
 param name string
 param location string
+param databaseName string = 'astroform-db'
 
-resource cosmos 'Microsoft.DocumentDB/databaseAccounts@2023-03-15' = {
+resource account 'Microsoft.DocumentDB/databaseAccounts@2023-03-15' = {
   name: name
   location: location
   kind: 'GlobalDocumentDB'
@@ -9,3 +10,48 @@ resource cosmos 'Microsoft.DocumentDB/databaseAccounts@2023-03-15' = {
     databaseAccountOfferType: 'Standard'
   }
 }
+
+resource database 'Microsoft.DocumentDB/databaseAccounts/sqlDatabases@2023-03-15' = {
+  parent: account
+  name: databaseName
+  properties: {
+    resource: {
+      id: databaseName
+    }
+    options: {}
+  }
+}
+
+var containers = [
+  {
+    name: 'Users'
+    partition: '/id'
+  }
+  {
+    name: 'Forms'
+    partition: '/userId'
+  }
+  {
+    name: 'FormSubmissions'
+    partition: '/formId'
+  }
+  {
+    name: 'ActivityLogs'
+    partition: '/partitionKey'
+  }
+]
+
+resource containerResources 'Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers@2023-03-15' = [for c in containers: {
+  parent: database
+  name: c.name
+  properties: {
+    resource: {
+      id: c.name
+      partitionKey: {
+        paths: [c.partition]
+        kind: 'Hash'
+      }
+    }
+    options: {}
+  }
+}]

--- a/src/Domain/Entities.cs
+++ b/src/Domain/Entities.cs
@@ -1,0 +1,146 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace AstroForm.Domain;
+
+public enum UserRole
+{
+    FortuneTeller,
+    Assistant,
+    Admin
+}
+
+public enum FormStatus
+{
+    Draft,
+    Published
+}
+
+public class User
+{
+    [Key]
+    public string Id { get; set; }
+
+    [Required]
+    [StringLength(100)]
+    public string DisplayName { get; set; }
+
+    [Required]
+    [EmailAddress]
+    public string Email { get; set; }
+
+    [Required]
+    public UserRole Role { get; set; }
+
+    public DateTime CreatedAt { get; set; }
+
+    public DateTime UpdatedAt { get; set; }
+
+    public virtual ICollection<Form> Forms { get; set; }
+    public virtual ICollection<ActivityLog> ActivityLogs { get; set; }
+}
+
+public class Form
+{
+    [Key]
+    public Guid Id { get; set; }
+
+    [Required]
+    public string UserId { get; set; }
+
+    [Required]
+    [StringLength(200)]
+    public string Name { get; set; }
+
+    public string Description { get; set; }
+
+    [StringLength(100)]
+    public string NavigationText { get; set; }
+
+    public string ThankYouPageUrl { get; set; }
+
+    [Required]
+    public FormStatus Status { get; set; }
+
+    public DateTime CreatedAt { get; set; }
+
+    public DateTime UpdatedAt { get; set; }
+
+    [ForeignKey("UserId")]
+    public virtual User User { get; set; }
+    public virtual ICollection<FormItem> FormItems { get; set; }
+    public virtual ICollection<FormSubmission> FormSubmissions { get; set; }
+}
+
+public class FormItem
+{
+    [Key]
+    public Guid Id { get; set; }
+
+    [Required]
+    public Guid FormId { get; set; }
+
+    [Required]
+    [StringLength(50)]
+    public string Type { get; set; }
+
+    [Required]
+    [StringLength(150)]
+    public string Label { get; set; }
+
+    public string Placeholder { get; set; }
+
+    public string ValidationRules { get; set; }
+
+    [Required]
+    public int DisplayOrder { get; set; }
+
+    [Required]
+    public bool IsDefault { get; set; }
+
+    [ForeignKey("FormId")]
+    public virtual Form Form { get; set; }
+}
+
+public class FormSubmission
+{
+    [Key]
+    public Guid Id { get; set; }
+
+    [Required]
+    public Guid FormId { get; set; }
+
+    [Required]
+    public string Answers { get; set; }
+
+    public DateTime SubmittedAt { get; set; }
+
+    public string SubmitterInfo { get; set; }
+
+    [ForeignKey("FormId")]
+    public virtual Form Form { get; set; }
+}
+
+public class ActivityLog
+{
+    [Key]
+    public long Id { get; set; }
+
+    [Required]
+    public DateTime Timestamp { get; set; }
+
+    public string UserId { get; set; }
+
+    public Guid? FormId { get; set; }
+
+    [Required]
+    [StringLength(100)]
+    public string ActionType { get; set; }
+
+    public string Details { get; set; }
+
+    [ForeignKey("UserId")]
+    public virtual User User { get; set; }
+}

--- a/src/Infra/Cosmos/ICosmosRepository.cs
+++ b/src/Infra/Cosmos/ICosmosRepository.cs
@@ -1,0 +1,11 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+namespace AstroForm.Infra.Cosmos;
+
+public interface ICosmosRepository<T>
+{
+    Task<T?> GetAsync(string id, string partitionKey);
+    Task<IEnumerable<T>> QueryAsync(string query);
+    Task SaveAsync(T entity);
+    Task DeleteAsync(string id, string partitionKey);
+}


### PR DESCRIPTION
## Summary
- define Cosmos DB account with collections in `cosmos.bicep`
- add JSON schema outline for Cosmos DB containers
- implement domain entities based on docs
- add `ICosmosRepository` interface for infrastructure

## Testing
- `dotnet build`
- `dotnet test`
- `dotnet format`


------
https://chatgpt.com/codex/tasks/task_e_6855eca00598832085a72de5373ebf89