### PR TITLE
Implement basic answer CSV export

### DIFF
--- a/src/Api/Functions/AnswersFunctions.cs
+++ b/src/Api/Functions/AnswersFunctions.cs
@@ -1,6 +1,8 @@
 using System.Net;
 using System.IO;
 using System.Threading.Tasks;
+using System.Collections.Generic;
+using System.Linq;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.Functions.Worker.Http;
 using Microsoft.Extensions.Logging;
@@ -12,6 +14,7 @@ public class AnswersFunctions
 {
     private readonly ILogger _logger;
     private readonly IEncryptionService _encryptionService;
+    private static readonly List<string> _answers = new();
 
     public AnswersFunctions(ILogger<AnswersFunctions> logger, IEncryptionService encryptionService)
     {
@@ -27,6 +30,7 @@ public class AnswersFunctions
         _logger.LogInformation("PostAnswer called");
         var body = await new StreamReader(req.Body).ReadToEndAsync();
         var encrypted = _encryptionService.Encrypt(body);
+        _answers.Add(encrypted);
         var res = req.CreateResponse(HttpStatusCode.OK);
         res.WriteString(encrypted);
         return res;
@@ -39,7 +43,21 @@ public class AnswersFunctions
     {
         _logger.LogInformation("GetAnswers called");
         var res = req.CreateResponse(HttpStatusCode.OK);
-        res.WriteString("answers list");
+        var list = string.Join("\n", _answers);
+        res.WriteString(list);
+        return res;
+    }
+
+    [Function("GetAnswersCsv")]
+    public HttpResponseData GetAnswersCsv([
+        HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "answers/csv")]
+        HttpRequestData req)
+    {
+        _logger.LogInformation("GetAnswersCsv called");
+        var res = req.CreateResponse(HttpStatusCode.OK);
+        var csv = string.Join("\n", _answers.Select(a => $"\"{a}\""));
+        res.Headers.Add("Content-Disposition", "attachment; filename=answers.csv");
+        res.WriteString(csv);
         return res;
     }
 }

--- a/src/Presentation.Client/Components/CsvExportButton.razor
+++ b/src/Presentation.Client/Components/CsvExportButton.razor
@@ -1,1 +1,14 @@
-<div>CsvExportButton component</div>
+<button class="btn btn-primary" @onclick="Download">Export CSV</button>
+
+@using Microsoft.JSInterop
+@code {
+    [Inject] private HttpClient Http { get; set; } = default!;
+    [Inject] private IJSRuntime JS { get; set; } = default!;
+
+    private async Task Download()
+    {
+        using var stream = await Http.GetStreamAsync("api/answers/csv");
+        using var streamRef = new DotNetStreamReference(stream);
+        await JS.InvokeVoidAsync("downloadFileFromStream", "answers.csv", streamRef);
+    }
+}

--- a/src/Presentation.Client/Layout/NavMenu.razor
+++ b/src/Presentation.Client/Layout/NavMenu.razor
@@ -24,6 +24,11 @@
                 <span class="bi bi-list-nested-nav-menu" aria-hidden="true"></span> Weather
             </NavLink>
         </div>
+        <div class="nav-item px-3">
+            <NavLink class="nav-link" href="answerreview">
+                <span class="bi bi-table" aria-hidden="true"></span> Answers
+            </NavLink>
+        </div>
     </nav>
 </div>
 

--- a/src/Presentation.Client/Pages/AnswerReview.razor
+++ b/src/Presentation.Client/Pages/AnswerReview.razor
@@ -1,2 +1,35 @@
 @page "/answerreview"
-<h1>AnswerReview</h1>
+
+<h1>Answers</h1>
+
+<CsvExportButton />
+
+@if (answers is null)
+{
+    <p><em>Loading...</em></p>
+}
+else if (answers.Count == 0)
+{
+    <p>No answers yet.</p>
+}
+else
+{
+    <ul>
+        @foreach (var a in answers)
+        {
+            <li>@a</li>
+        }
+    </ul>
+}
+
+@code {
+    private List<string>? answers;
+
+    [Inject] private HttpClient Http { get; set; } = default!;
+
+    protected override async Task OnInitializedAsync()
+    {
+        var text = await Http.GetStringAsync("api/answers");
+        answers = text.Split('\n', StringSplitOptions.RemoveEmptyEntries).ToList();
+    }
+}

--- a/src/Presentation.Client/wwwroot/index.html
+++ b/src/Presentation.Client/wwwroot/index.html
@@ -26,6 +26,19 @@
         <a class="dismiss">🗙</a>
     </div>
     <script src="_framework/blazor.webassembly.js"></script>
+    <script>
+        window.downloadFileFromStream = async (filename, contentStreamReference) => {
+            const arrayBuffer = await contentStreamReference.arrayBuffer();
+            const blob = new Blob([arrayBuffer]);
+            const url = URL.createObjectURL(blob);
+            const anchorElement = document.createElement('a');
+            anchorElement.href = url;
+            anchorElement.download = filename ?? '';
+            anchorElement.click();
+            anchorElement.remove();
+            URL.revokeObjectURL(url);
+        };
+    </script>
 </body>
 
 </html>


### PR DESCRIPTION
## Summary
- collect posted answers in-memory
- add API endpoint to download answers as CSV
- show answers in UI with download button
- add JS helper for file download

## Testing
- `dotnet test`
- `dotnet build --no-restore`


------
https://chatgpt.com/codex/tasks/task_e_6855f7f2be4483208aedcb7fc52f06c8