### PR TITLE
Implement form preview and publish HTML

### DIFF
--- a/src/Api/Program.cs
+++ b/src/Api/Program.cs
@@ -1,10 +1,19 @@
 using AstroForm.Domain.Entities;
 using AstroForm.Domain.Repositories;
 using AstroForm.Infra;
+using AstroForm.Application;
+using System.IO;
 
 var builder = WebApplication.CreateBuilder(args);
 
 builder.Services.AddSingleton<IFormRepository, InMemoryFormRepository>();
+builder.Services.AddSingleton(sp =>
+{
+    var env = sp.GetRequiredService<IHostEnvironment>();
+    var publicDir = Path.Combine(env.ContentRootPath, "public");
+    var previewDir = Path.Combine(env.ContentRootPath, "preview");
+    return new FormPublishService(publicDir, previewDir);
+});
 
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
@@ -28,6 +37,21 @@ app.MapPost("/forms/{id}/save", async (Guid id, Form form, IFormRepository repo)
     form.Id = id;
     await repo.SaveAsync(form);
     return Results.Ok(form);
+});
+
+app.MapPost("/forms/{id}/preview", async (Guid id, Form form, FormPublishService publisher) =>
+{
+    form.Id = id;
+    var path = await publisher.GeneratePreviewAsync(form);
+    return Results.Ok(new { path });
+});
+
+app.MapPost("/forms/{id}/publish", async (Guid id, Form form, IFormRepository repo, FormPublishService publisher) =>
+{
+    form.Id = id;
+    var path = await publisher.PublishAsync(form);
+    await repo.SaveAsync(form);
+    return Results.Ok(new { path });
 });
 
 app.Run();

--- a/src/Application.Tests/FormPublishServiceTests.cs
+++ b/src/Application.Tests/FormPublishServiceTests.cs
@@ -1,0 +1,60 @@
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using AstroForm.Application;
+using AstroForm.Domain.Entities;
+using Xunit;
+
+namespace AstroForm.Tests
+{
+    public class FormPublishServiceTests
+    {
+        private static Form CreateSampleForm()
+        {
+            var form = new Form
+            {
+                Id = Guid.NewGuid(),
+                Name = "Test",
+                Description = "desc",
+                Status = FormStatus.Draft
+            };
+            form.FormItems.Add(new FormItem
+            {
+                Id = Guid.NewGuid(),
+                FormId = form.Id,
+                Type = "text",
+                Label = "Name",
+                DisplayOrder = 1,
+                IsDefault = true
+            });
+            return form;
+        }
+
+        [Fact]
+        public async Task GeneratePreview_WritesFile()
+        {
+            var previewDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+            var service = new FormPublishService("unused", previewDir);
+            var form = CreateSampleForm();
+
+            var path = await service.GeneratePreviewAsync(form);
+
+            Assert.True(File.Exists(path));
+            var html = await File.ReadAllTextAsync(path);
+            Assert.Contains("Test", html);
+        }
+
+        [Fact]
+        public async Task Publish_WritesFileAndUpdatesStatus()
+        {
+            var publishDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+            var service = new FormPublishService(publishDir, "unused");
+            var form = CreateSampleForm();
+
+            var path = await service.PublishAsync(form);
+
+            Assert.True(File.Exists(path));
+            Assert.Equal(FormStatus.Published, form.Status);
+        }
+    }
+}

--- a/src/Application/FormPublishService.cs
+++ b/src/Application/FormPublishService.cs
@@ -1,0 +1,64 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Text;
+using System.Threading.Tasks;
+using AstroForm.Domain.Entities;
+
+namespace AstroForm.Application
+{
+    public class FormPublishService
+    {
+        private readonly string _publicDir;
+        private readonly string _previewDir;
+
+        public FormPublishService(string publicDir, string previewDir)
+        {
+            _publicDir = publicDir;
+            _previewDir = previewDir;
+        }
+
+        public async Task<string> GeneratePreviewAsync(Form form)
+        {
+            Directory.CreateDirectory(_previewDir);
+            var path = Path.Combine(_previewDir, $"{form.Id}.html");
+            var html = BuildHtml(form);
+            await File.WriteAllTextAsync(path, html);
+            return path;
+        }
+
+        public async Task<string> PublishAsync(Form form)
+        {
+            Directory.CreateDirectory(_publicDir);
+            var path = Path.Combine(_publicDir, $"{form.Id}.html");
+            var html = BuildHtml(form);
+            await File.WriteAllTextAsync(path, html);
+            form.Status = FormStatus.Published;
+            return path;
+        }
+
+        private static string BuildHtml(Form form)
+        {
+            var sb = new StringBuilder();
+            sb.AppendLine("<!DOCTYPE html>");
+            sb.AppendLine("<html><body>");
+            sb.AppendLine($"<h1>{WebUtility.HtmlEncode(form.Name)}</h1>");
+            if (!string.IsNullOrWhiteSpace(form.Description))
+            {
+                sb.AppendLine($"<p>{WebUtility.HtmlEncode(form.Description)}</p>");
+            }
+            sb.AppendLine("<form>");
+            foreach (var item in form.FormItems.OrderBy(i => i.DisplayOrder))
+            {
+                var label = WebUtility.HtmlEncode(item.Label);
+                var placeholder = WebUtility.HtmlEncode(item.Placeholder ?? string.Empty);
+                sb.AppendLine($"<label>{label}<input name=\"{item.Id}\" placeholder=\"{placeholder}\" /></label><br/>");
+            }
+            sb.AppendLine("<button type=\"submit\">Submit</button>");
+            sb.AppendLine("</form>");
+            sb.AppendLine("</body></html>");
+            return sb.ToString();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `FormPublishService` to generate preview/public HTML
- expose preview & publish endpoints in API
- test HTML generation and publish status

## Testing
- `dotnet build src/AstroForm.sln -v minimal`
- `dotnet test src/AstroForm.sln -v minimal`
- `dotnet format src/AstroForm.sln --no-restore`

------
https://chatgpt.com/codex/tasks/task_e_6856056ef8d08320b0ca3d56c1ca8500