### PR TITLE
Add answer list feature

### DIFF
--- a/src/Api/Program.cs
+++ b/src/Api/Program.cs
@@ -14,6 +14,7 @@ builder.Services.AddSingleton(sp =>
     var previewDir = Path.Combine(env.ContentRootPath, "preview");
     return new FormPublishService(publicDir, previewDir);
 });
+builder.Services.AddSingleton<FormAnswerService>();
 
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
@@ -30,6 +31,12 @@ app.MapGet("/forms/{id}", async (Guid id, IFormRepository repo) =>
 {
     var form = await repo.GetByIdAsync(id);
     return form is null ? Results.NotFound() : Results.Ok(form);
+});
+
+app.MapGet("/forms/{id}/answers", async (Guid id, FormAnswerService service) =>
+{
+    var answers = await service.GetSubmissionsAsync(id);
+    return answers.Count == 0 ? Results.NotFound() : Results.Ok(answers);
 });
 
 app.MapPost("/forms/{id}/save", async (Guid id, Form form, IFormRepository repo) =>

--- a/src/Application.Tests/FormAnswerServiceTests.cs
+++ b/src/Application.Tests/FormAnswerServiceTests.cs
@@ -1,0 +1,27 @@
+using System;
+using System.Threading.Tasks;
+using AstroForm.Application;
+using AstroForm.Domain.Entities;
+using AstroForm.Infra;
+using Xunit;
+
+namespace AstroForm.Tests
+{
+    public class FormAnswerServiceTests
+    {
+        [Fact]
+        public async Task GetSubmissions_ReturnsSavedSubmissions()
+        {
+            var repo = new InMemoryFormRepository();
+            var form = new Form { Id = Guid.NewGuid(), Status = FormStatus.Draft };
+            form.FormSubmissions.Add(new FormSubmission { Id = Guid.NewGuid(), FormId = form.Id, Answers = "ans" });
+            await repo.SaveAsync(form);
+
+            var service = new FormAnswerService(repo);
+            var list = await service.GetSubmissionsAsync(form.Id);
+
+            Assert.Single(list);
+            Assert.Equal("ans", list[0].Answers);
+        }
+    }
+}

--- a/src/Application/FormAnswerService.cs
+++ b/src/Application/FormAnswerService.cs
@@ -1,0 +1,25 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using AstroForm.Domain.Entities;
+using AstroForm.Domain.Repositories;
+
+namespace AstroForm.Application
+{
+    public class FormAnswerService
+    {
+        private readonly IFormRepository _repository;
+
+        public FormAnswerService(IFormRepository repository)
+        {
+            _repository = repository;
+        }
+
+        public async Task<IReadOnlyList<FormSubmission>> GetSubmissionsAsync(Guid formId)
+        {
+            var form = await _repository.GetByIdAsync(formId);
+            return form?.FormSubmissions.ToList() ?? new List<FormSubmission>();
+        }
+    }
+}

--- a/src/Domain/IFormRepository.cs
+++ b/src/Domain/IFormRepository.cs
@@ -8,5 +8,6 @@ namespace AstroForm.Domain.Repositories
     {
         Task<Form?> GetByIdAsync(Guid id);
         Task SaveAsync(Form form);
+        Task<IReadOnlyList<FormSubmission>> GetSubmissionsAsync(Guid formId);
     }
 }

--- a/src/Infra/InMemoryFormRepository.cs
+++ b/src/Infra/InMemoryFormRepository.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using AstroForm.Domain.Entities;
 using AstroForm.Domain.Repositories;
@@ -20,6 +22,15 @@ namespace AstroForm.Infra
         {
             _store[form.Id] = form;
             return Task.CompletedTask;
+        }
+
+        public Task<IReadOnlyList<FormSubmission>> GetSubmissionsAsync(Guid formId)
+        {
+            if (_store.TryGetValue(formId, out var form))
+            {
+                return Task.FromResult((IReadOnlyList<FormSubmission>)form.FormSubmissions.ToList());
+            }
+            return Task.FromResult((IReadOnlyList<FormSubmission>)new List<FormSubmission>());
         }
     }
 }


### PR DESCRIPTION
## Summary
- add `GetSubmissionsAsync` to domain repository
- implement answer retrieval in the in-memory repository
- introduce `FormAnswerService` for listing submissions
- expose `/forms/{id}/answers` endpoint in API
- test `FormAnswerService`

## Testing
- `dotnet build src/AstroForm.sln` *(fails: Unable to resolve NuGet packages)*
- `dotnet test src/AstroForm.sln` *(fails: Unable to resolve NuGet packages)*
- `dotnet format src/AstroForm.sln` *(fails: Restore operation failed)*

------
https://chatgpt.com/codex/tasks/task_e_6856079c0cdc83209ab92a0d30f46a97