### PR TITLE
Implement temporary save for public form inputs

### DIFF
--- a/src/Application.Tests/FormPublishServiceTests.cs
+++ b/src/Application.Tests/FormPublishServiceTests.cs
@@ -42,6 +42,7 @@ namespace AstroForm.Tests
             Assert.True(File.Exists(path));
             var html = await File.ReadAllTextAsync(path);
             Assert.Contains("Test", html);
+            Assert.Contains("localStorage.setItem", html);
         }
 
         [Fact]

--- a/src/Application/FormPublishService.cs
+++ b/src/Application/FormPublishService.cs
@@ -57,6 +57,21 @@ namespace AstroForm.Application
             }
             sb.AppendLine("<button type=\"submit\">Submit</button>");
             sb.AppendLine("</form>");
+
+            sb.AppendLine("<script>");
+            sb.AppendLine("document.addEventListener('DOMContentLoaded', function () {");
+            sb.AppendLine($"  var formId = '{form.Id}';");
+            sb.AppendLine("  document.querySelectorAll('form input').forEach(function(input) {");
+            sb.AppendLine("    var key = 'form-' + formId + '-' + input.name;");
+            sb.AppendLine("    var saved = localStorage.getItem(key);");
+            sb.AppendLine("    if (saved) { input.value = saved; }");
+            sb.AppendLine("    input.addEventListener('blur', function () {");
+            sb.AppendLine("      localStorage.setItem(key, input.value);");
+            sb.AppendLine("    });");
+            sb.AppendLine("  });");
+            sb.AppendLine("});");
+            sb.AppendLine("</script>");
+
             sb.AppendLine("</body></html>");
             return sb.ToString();
         }


### PR DESCRIPTION
## Summary
- add localStorage script in generated public forms to auto-save input values
- check for script presence in preview HTML test

## Testing
- `dotnet format src/AstroForm.sln --no-restore -v diag`
- `dotnet build src/AstroForm.sln`
- `dotnet test src/AstroForm.sln`


------
https://chatgpt.com/codex/tasks/task_e_68560ab0043c83208b2447ad4b796666