### PR TITLE
Add Log Viewer page with API support

### DIFF
--- a/src/Api/LogViewer.html
+++ b/src/Api/LogViewer.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8" />
+    <title>Log Viewer</title>
+    <style>
+        table { border-collapse: collapse; width: 100%; }
+        th, td { border: 1px solid #ccc; padding: 4px; }
+    </style>
+</head>
+<body>
+    <h1>Activity Logs</h1>
+    <table id="logTable">
+        <thead>
+            <tr>
+                <th>Timestamp</th>
+                <th>User</th>
+                <th>Form</th>
+                <th>Action</th>
+                <th>Details</th>
+            </tr>
+        </thead>
+        <tbody></tbody>
+    </table>
+    <script>
+        async function loadLogs() {
+            const res = await fetch('/logs');
+            const logs = await res.json();
+            const tbody = document.querySelector('#logTable tbody');
+            tbody.innerHTML = '';
+            logs.forEach(log => {
+                const tr = document.createElement('tr');
+                tr.innerHTML = `<td>${log.timestamp}</td><td>${log.userId ?? ''}</td><td>${log.formId ?? ''}</td><td>${log.actionType}</td><td>${log.details ?? ''}</td>`;
+                tbody.appendChild(tr);
+            });
+        }
+        loadLogs();
+    </script>
+</body>
+</html>

--- a/src/Application.Tests/ActivityLogServiceTests.cs
+++ b/src/Application.Tests/ActivityLogServiceTests.cs
@@ -1,0 +1,26 @@
+using System;
+using System.Threading.Tasks;
+using AstroForm.Application;
+using AstroForm.Domain.Entities;
+using AstroForm.Infra;
+using Xunit;
+
+namespace AstroForm.Tests
+{
+    public class ActivityLogServiceTests
+    {
+        [Fact]
+        public async Task AddAndRetrieve_Log()
+        {
+            var repo = new InMemoryActivityLogRepository();
+            var service = new ActivityLogService(repo);
+            var log = new ActivityLog { ActionType = "TEST", Details = "detail", UserId = "u1" };
+
+            await service.AddLogAsync(log);
+            var logs = await service.GetLogsAsync("u1", null);
+
+            Assert.Single(logs);
+            Assert.Equal("TEST", logs[0].ActionType);
+        }
+    }
+}

--- a/src/Application/ActivityLogService.cs
+++ b/src/Application/ActivityLogService.cs
@@ -1,0 +1,29 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using AstroForm.Domain.Entities;
+using AstroForm.Domain.Repositories;
+
+namespace AstroForm.Application
+{
+    public class ActivityLogService
+    {
+        private readonly IActivityLogRepository _repository;
+
+        public ActivityLogService(IActivityLogRepository repository)
+        {
+            _repository = repository;
+        }
+
+        public Task<IReadOnlyList<ActivityLog>> GetLogsAsync(string? userId = null, Guid? formId = null)
+        {
+            return _repository.GetLogsAsync(userId, formId);
+        }
+
+        public Task AddLogAsync(ActivityLog log)
+        {
+            log.Timestamp = DateTime.UtcNow;
+            return _repository.AddLogAsync(log);
+        }
+    }
+}

--- a/src/Domain/IActivityLogRepository.cs
+++ b/src/Domain/IActivityLogRepository.cs
@@ -1,0 +1,13 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using AstroForm.Domain.Entities;
+
+namespace AstroForm.Domain.Repositories
+{
+    public interface IActivityLogRepository
+    {
+        Task<IReadOnlyList<ActivityLog>> GetLogsAsync(string? userId = null, Guid? formId = null);
+        Task AddLogAsync(ActivityLog log);
+    }
+}

--- a/src/Infra/InMemoryActivityLogRepository.cs
+++ b/src/Infra/InMemoryActivityLogRepository.cs
@@ -1,0 +1,35 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using AstroForm.Domain.Entities;
+using AstroForm.Domain.Repositories;
+
+namespace AstroForm.Infra
+{
+    public class InMemoryActivityLogRepository : IActivityLogRepository
+    {
+        private readonly ConcurrentBag<ActivityLog> _logs = new();
+
+        public Task AddLogAsync(ActivityLog log)
+        {
+            _logs.Add(log);
+            return Task.CompletedTask;
+        }
+
+        public Task<IReadOnlyList<ActivityLog>> GetLogsAsync(string? userId = null, Guid? formId = null)
+        {
+            IEnumerable<ActivityLog> query = _logs;
+            if (!string.IsNullOrEmpty(userId))
+            {
+                query = query.Where(l => l.UserId == userId);
+            }
+            if (formId.HasValue)
+            {
+                query = query.Where(l => l.FormId == formId);
+            }
+            return Task.FromResult((IReadOnlyList<ActivityLog>)query.OrderByDescending(l => l.Timestamp).ToList());
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- implement ActivityLog repository and service
- add in-memory log store
- expose log APIs and a simple HTML viewer
- add unit test for ActivityLogService

## Testing
- `dotnet build src/AstroForm.sln`
- `dotnet test src/AstroForm.sln`
- `dotnet format src/AstroForm.sln --no-restore`

------
https://chatgpt.com/codex/tasks/task_e_68560d6d85cc83208e74a5f67abebb0e