### PR TITLE
Add Azure free tier IaC templates

### DIFF
--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -1,0 +1,48 @@
+param prefix string
+param env string
+param location string = resourceGroup().location
+
+var suffix = env == 'prod' ? '' : '-${env}'
+
+module storage './modules/blob.bicep' = {
+  name: 'storage'
+  params: {
+    name: '${prefix}storage${suffix}'
+    location: location
+  }
+}
+
+module kv './modules/keyvault.bicep' = {
+  name: 'kv'
+  params: {
+    name: '${prefix}kv${suffix}'
+    location: location
+    tenantId: tenant().tenantId
+  }
+}
+
+module cosmos './modules/cosmos.bicep' = {
+  name: 'cosmos'
+  params: {
+    name: '${prefix}cosmos${suffix}'
+    location: location
+  }
+}
+
+module function './modules/function.bicep' = {
+  name: 'function'
+  params: {
+    name: '${prefix}func${suffix}'
+    location: location
+    storageAccountName: storage.outputs.storageAccountName
+  }
+  dependsOn: [storage]
+}
+
+module swa './modules/swa.bicep' = {
+  name: 'swa'
+  params: {
+    name: '${prefix}swa${suffix}'
+    location: location
+  }
+}

--- a/infra/modules/blob.bicep
+++ b/infra/modules/blob.bicep
@@ -1,0 +1,16 @@
+param name string
+param location string
+
+resource storage 'Microsoft.Storage/storageAccounts@2022-09-01' = {
+  name: name
+  location: location
+  sku: {
+    name: 'Standard_LRS'
+  }
+  kind: 'StorageV2'
+  properties: {
+    accessTier: 'Hot'
+  }
+}
+
+output storageAccountName string = storage.name

--- a/infra/modules/cosmos.bicep
+++ b/infra/modules/cosmos.bicep
@@ -1,0 +1,20 @@
+param name string
+param location string
+
+resource cosmos 'Microsoft.DocumentDB/databaseAccounts@2023-04-15' = {
+  name: name
+  location: location
+  kind: 'GlobalDocumentDB'
+  properties: {
+    databaseAccountOfferType: 'Standard'
+    enableFreeTier: true
+    locations: [
+      {
+        locationName: location
+        failoverPriority: 0
+      }
+    ]
+  }
+}
+
+output accountName string = cosmos.name

--- a/infra/modules/function.bicep
+++ b/infra/modules/function.bicep
@@ -1,0 +1,45 @@
+param name string
+param location string
+param storageAccountName string
+
+resource storage 'Microsoft.Storage/storageAccounts@2022-09-01' existing = {
+  name: storageAccountName
+}
+
+resource plan 'Microsoft.Web/serverfarms@2022-09-01' = {
+  name: '${name}-plan'
+  location: location
+  sku: {
+    name: 'Y1'
+    tier: 'Dynamic'
+  }
+  kind: 'functionapp'
+}
+
+resource func 'Microsoft.Web/sites@2022-09-01' = {
+  name: name
+  location: location
+  kind: 'functionapp'
+  properties: {
+    serverFarmId: plan.id
+    httpsOnly: true
+    siteConfig: {
+      appSettings: [
+        {
+          name: 'AzureWebJobsStorage'
+          value: 'DefaultEndpointsProtocol=https;AccountName=${storage.name};AccountKey=${listKeys(storage.id, storage.apiVersion).keys[0].value};EndpointSuffix=core.windows.net'
+        }
+        {
+          name: 'FUNCTIONS_EXTENSION_VERSION'
+          value: '~4'
+        }
+        {
+          name: 'FUNCTIONS_WORKER_RUNTIME'
+          value: 'dotnet-isolated'
+        }
+      ]
+    }
+  }
+}
+
+output functionAppName string = func.name

--- a/infra/modules/keyvault.bicep
+++ b/infra/modules/keyvault.bicep
@@ -1,0 +1,18 @@
+param name string
+param location string
+param tenantId string
+
+resource kv 'Microsoft.KeyVault/vaults@2023-02-01' = {
+  name: name
+  location: location
+  properties: {
+    tenantId: tenantId
+    enableRbacAuthorization: true
+    sku: {
+      family: 'A'
+      name: 'standard'
+    }
+  }
+}
+
+output vaultUri string = kv.properties.vaultUri

--- a/infra/modules/swa.bicep
+++ b/infra/modules/swa.bicep
@@ -1,0 +1,13 @@
+param name string
+param location string
+
+resource swa 'Microsoft.Web/staticSites@2022-09-01' = {
+  name: name
+  location: location
+  sku: {
+    name: 'Free'
+    tier: 'Free'
+  }
+}
+
+output staticSiteName string = swa.name

--- a/infra/parameters/dev.json
+++ b/infra/parameters/dev.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "prefix": { "value": "demoapp" },
+    "env": { "value": "dev" },
+    "location": { "value": "japaneast" }
+  }
+}

--- a/infra/parameters/prod.json
+++ b/infra/parameters/prod.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "prefix": { "value": "demoapp" },
+    "env": { "value": "prod" },
+    "location": { "value": "japaneast" }
+  }
+}


### PR DESCRIPTION
## Summary
- add infrastructure Bicep templates to deploy resources on Azure free tier
- include modules for storage, functions, static web apps, Key Vault, and Cosmos DB
- supply dev/prod parameter files

## Testing
- `dotnet build src/AstroForm.sln -c Release`
- `dotnet test src/AstroForm.sln -c Release`
- `dotnet format src/AstroForm.sln --no-restore`


------
https://chatgpt.com/codex/tasks/task_e_68560f0e21b08320b5976bf643c51e58