### PR TITLE
Setup docker environment and add smoke test

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,34 @@
+version: '3.8'
+services:
+  cosmos:
+    image: mcr.microsoft.com/cosmosdb/linux/azure-cosmos-emulator
+    restart: unless-stopped
+    ports:
+      - "8081:8081"
+      - "10251-10255:10251-10255"
+    environment:
+      - AZURE_COSMOS_EMULATOR_PARTITION_COUNT=2
+      - AZURE_COSMOS_EMULATOR_ENABLE_DATA_PERSISTENCE=true
+    volumes:
+      - cosmos-data:/data
+  azurite:
+    image: mcr.microsoft.com/azure-storage/azurite
+    restart: unless-stopped
+    ports:
+      - "10000:10000"
+      - "10001:10001"
+      - "10002:10002"
+    volumes:
+      - azurite-data:/data
+  swa:
+    image: ghcr.io/azure/static-web-apps-cli
+    command: ["tail", "-f", "/dev/null"]
+    tty: true
+    ports:
+      - "4280:4280"
+    volumes:
+      - .:/app
+    working_dir: /app
+volumes:
+  cosmos-data:
+  azurite-data:

--- a/docker/azurite/README.md
+++ b/docker/azurite/README.md
@@ -1,0 +1,5 @@
+# Azurite
+
+This folder holds Azurite related configuration if needed.
+The standard `mcr.microsoft.com/azure-storage/azurite` image is referenced by
+the docker-compose file.

--- a/docker/cosmos/README.md
+++ b/docker/cosmos/README.md
@@ -1,0 +1,5 @@
+# Cosmos Emulator
+
+This folder is reserved for any custom configuration for the Cosmos DB emulator.
+The Docker image from `mcr.microsoft.com/cosmosdb/linux/azure-cosmos-emulator`
+is used in `docker-compose.yml`.

--- a/src/Application.Tests/Application.Tests.csproj
+++ b/src/Application.Tests/Application.Tests.csproj
@@ -14,6 +14,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="xunit" Version="2.5.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Application.Tests/SmokeTests.cs
+++ b/src/Application.Tests/SmokeTests.cs
@@ -1,0 +1,30 @@
+using AstroForm.Application;
+using AstroForm.Domain.Repositories;
+using AstroForm.Infra;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Application.Tests;
+
+public class SmokeTests
+{
+    [Fact]
+    public void ServiceProviderBuildsWithoutExceptions()
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton<IFormRepository, InMemoryFormRepository>();
+        services.AddSingleton<IActivityLogRepository, InMemoryActivityLogRepository>();
+        services.AddSingleton<IUserRepository, InMemoryUserRepository>();
+        services.AddSingleton(sp => new FormPublishService("/tmp/public", "/tmp/preview"));
+        services.AddSingleton<FormAnswerService>();
+        services.AddSingleton<ActivityLogService>();
+        services.AddSingleton<UserService>();
+
+        var provider = services.BuildServiceProvider();
+
+        Assert.NotNull(provider.GetService<FormAnswerService>());
+        Assert.NotNull(provider.GetService<UserService>());
+        Assert.NotNull(provider.GetService<ActivityLogService>());
+        Assert.NotNull(provider.GetService<FormPublishService>());
+    }
+}


### PR DESCRIPTION
## Summary
- add docker-compose with Cosmos DB Emulator, Azurite and SWA CLI
- document emulator folders under `docker/`
- add smoke test for DI container in `Application.Tests`
- include Microsoft.Extensions.DependencyInjection for the tests

## Testing
- `dotnet format src/AstroForm.sln --verify-no-changes`
- `dotnet build src/AstroForm.sln --configuration Release`
- `dotnet test src/AstroForm.sln --no-build`


------
https://chatgpt.com/codex/tasks/task_e_6856297975388320a53829fb780a06e1