### PR TITLE
Implement form item editing

### DIFF
--- a/src/Application.Tests/FormEditorServiceTests.cs
+++ b/src/Application.Tests/FormEditorServiceTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using System.Threading.Tasks;
 using AstroForm.Application;
 using AstroForm.Domain.Entities;
@@ -56,6 +57,45 @@ namespace AstroForm.Tests
 
             Assert.Equal(8, service.CurrentForm.FormItems.Count);
             Assert.All(service.CurrentForm.FormItems, i => Assert.True(i.IsDefault));
+        }
+
+        [Fact]
+        public void AddItem_AppendsNewItem()
+        {
+            var repo = new InMemoryFormRepository();
+            using var service = new FormEditorService(repo);
+
+            var item = service.AddItem("text", "new");
+
+            Assert.Contains(item, service.CurrentForm.FormItems);
+            Assert.Equal(9, item.DisplayOrder);
+            Assert.False(item.IsDefault);
+        }
+
+        [Fact]
+        public void RemoveItem_DeletesItem()
+        {
+            var repo = new InMemoryFormRepository();
+            using var service = new FormEditorService(repo);
+
+            var item = service.AddItem("text", "temp");
+            service.RemoveItem(item.Id);
+
+            Assert.DoesNotContain(service.CurrentForm.FormItems, i => i.Id == item.Id);
+        }
+
+        [Fact]
+        public void UpdateItem_ChangesValues()
+        {
+            var repo = new InMemoryFormRepository();
+            using var service = new FormEditorService(repo);
+
+            var item = service.AddItem("text", "old");
+            service.UpdateItem(item.Id, "new", "ph");
+
+            var updated = service.CurrentForm.FormItems.First(i => i.Id == item.Id);
+            Assert.Equal("new", updated.Label);
+            Assert.Equal("ph", updated.Placeholder);
         }
     }
 }

--- a/src/Application/FormEditorService.cs
+++ b/src/Application/FormEditorService.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Threading.Tasks;
 using System.Collections.Generic;
+using System.Linq;
 using Timer = System.Timers.Timer;
 using AstroForm.Domain.Entities;
 using AstroForm.Domain.Repositories;
@@ -51,6 +52,51 @@ namespace AstroForm.Application
         public void UpdateDescription(string description)
         {
             CurrentForm.Description = description;
+            RestartTimer();
+        }
+
+        public FormItem AddItem(string type, string label, string? placeholder = null)
+        {
+            var item = new FormItem
+            {
+                Id = Guid.NewGuid(),
+                FormId = CurrentForm.Id,
+                Type = type,
+                Label = label,
+                Placeholder = placeholder,
+                DisplayOrder = CurrentForm.FormItems.Count + 1,
+                IsDefault = false
+            };
+            CurrentForm.FormItems.Add(item);
+            RestartTimer();
+            return item;
+        }
+
+        public void RemoveItem(Guid itemId)
+        {
+            var item = CurrentForm.FormItems.FirstOrDefault(i => i.Id == itemId);
+            if (item == null || item.IsDefault)
+            {
+                return;
+            }
+            CurrentForm.FormItems.Remove(item);
+            var order = 1;
+            foreach (var i in CurrentForm.FormItems.OrderBy(i => i.DisplayOrder))
+            {
+                i.DisplayOrder = order++;
+            }
+            RestartTimer();
+        }
+
+        public void UpdateItem(Guid itemId, string label, string? placeholder = null)
+        {
+            var item = CurrentForm.FormItems.FirstOrDefault(i => i.Id == itemId);
+            if (item == null)
+            {
+                return;
+            }
+            item.Label = label;
+            item.Placeholder = placeholder;
             RestartTimer();
         }
 

--- a/src/Presentation.Client/Components/FormEditor.razor
+++ b/src/Presentation.Client/Components/FormEditor.razor
@@ -1,1 +1,35 @@
-<div class="form-editor">Form Editor Placeholder</div>
+<div class="form-editor">
+    <ul>
+        @foreach (var item in Service.CurrentForm.FormItems.OrderBy(i => i.DisplayOrder))
+        {
+            <li>
+                <input value="@item.Label" @onchange="e => OnEdit(item.Id, e.Value?.ToString() ?? string.Empty, item.Placeholder)" />
+                <input value="@item.Placeholder" @onchange="e => OnEdit(item.Id, item.Label, e.Value?.ToString())" />
+                @if (!item.IsDefault)
+                {
+                    <button @onclick="() => Remove(item.Id)">Delete</button>
+                }
+            </li>
+        }
+    </ul>
+    <button @onclick="Add">Add Item</button>
+</div>
+
+@code {
+    [Inject] public FormEditorService Service { get; set; } = default!;
+
+    private void Add()
+    {
+        Service.AddItem("text", "New Item");
+    }
+
+    private void Remove(Guid id)
+    {
+        Service.RemoveItem(id);
+    }
+
+    private void OnEdit(Guid id, string label, string? placeholder)
+    {
+        Service.UpdateItem(id, label, placeholder);
+    }
+}

--- a/src/Presentation.Client/Presentation.Client.csproj
+++ b/src/Presentation.Client/Presentation.Client.csproj
@@ -11,4 +11,11 @@
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="8.0.17" PrivateAssets="all" />
   </ItemGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\Application\Application.csproj" />
+    <ProjectReference Include="..\Domain\Domain.csproj" />
+    <ProjectReference Include="..\Infra\Infra.csproj" />
+    <ProjectReference Include="..\Presentation.Shared\Presentation.Shared.csproj" />
+  </ItemGroup>
+
 </Project>

--- a/src/Presentation.Client/Program.cs
+++ b/src/Presentation.Client/Program.cs
@@ -1,11 +1,16 @@
 using Microsoft.AspNetCore.Components.Web;
 using Microsoft.AspNetCore.Components.WebAssembly.Hosting;
 using Presentation.Client;
+using AstroForm.Application;
+using AstroForm.Domain.Repositories;
+using AstroForm.Infra;
 
 var builder = WebAssemblyHostBuilder.CreateDefault(args);
 builder.RootComponents.Add<App>("#app");
 builder.RootComponents.Add<HeadOutlet>("head::after");
 
 builder.Services.AddScoped(sp => new HttpClient { BaseAddress = new Uri(builder.HostEnvironment.BaseAddress) });
+builder.Services.AddScoped<IFormRepository, InMemoryFormRepository>();
+builder.Services.AddScoped<FormEditorService>();
 
 await builder.Build().RunAsync();

--- a/src/Presentation.Client/_Imports.razor
+++ b/src/Presentation.Client/_Imports.razor
@@ -9,3 +9,6 @@
 @using Presentation.Client
 @using Presentation.Client.Layout
 @using Presentation.Client.Components
+@using AstroForm.Application
+@using AstroForm.Domain.Entities
+@using System.Linq


### PR DESCRIPTION
## Summary
- add methods to `FormEditorService` to add, update and remove form items
- cover new service behaviour with unit tests
- wire up `FormEditorService` in client project
- implement simple form item editor UI

## Testing
- `dotnet test src/AstroForm.sln`

------
https://chatgpt.com/codex/tasks/task_e_685641e273708320bd1761bfc0bc08bd