### PR TITLE
Fix Functions build by updating SDK usage

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,0 +1,9 @@
+{
+  "sdk": {
+    "version": "8.0.411",
+    "rollForward": "latestFeature"
+  },
+  "msbuild-sdks": {
+    "Microsoft.NET.Sdk.Functions": "4.6.0"
+  }
+}

--- a/src/Functions/FormFunctions.cs
+++ b/src/Functions/FormFunctions.cs
@@ -69,7 +69,7 @@ public class FormFunctions
         string formId,
         string submissionId)
     {
-        var data = await req.ReadFromJsonAsync<EmailRequest>() ?? new EmailRequest();
+        var data = await req.ReadFromJsonAsync<EmailRequest>() ?? new EmailRequest(string.Empty);
         if (!Guid.TryParse(formId, out var fid) || !Guid.TryParse(submissionId, out var sid))
         {
             return new BadRequestResult();

--- a/src/Functions/Functions.csproj
+++ b/src/Functions/Functions.csproj
@@ -1,17 +1,19 @@
-<Project Sdk="Microsoft.NET.Sdk.Functions">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <AzureFunctionsVersion>v4</AzureFunctionsVersion>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
-    <OutputType>Exe</OutputType>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="1.17.0" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.17.0" OutputItemType="Analyzer" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.0.12" />
+    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="4.6.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.1.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.2" />
-    <PackageReference Include="Serilog" Version="2.12.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="6.6.2" />
+    <PackageReference Include="Swashbuckle.AspNetCore.Swagger" Version="6.6.2" />
+    <PackageReference Include="Serilog" Version="3.1.1" />
+    <PackageReference Include="Serilog.Extensions.Logging" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="8.0.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Domain\Domain.csproj" />

--- a/src/Functions/Program.cs
+++ b/src/Functions/Program.cs
@@ -1,7 +1,0 @@
-using Microsoft.Extensions.Hosting;
-
-var host = new HostBuilder()
-    .ConfigureFunctionsWorkerDefaults()
-    .Build();
-
-host.Run();

--- a/src/Functions/Startup.cs
+++ b/src/Functions/Startup.cs
@@ -5,6 +5,8 @@ using AstroForm.Domain.Services;
 using AstroForm.Infra;
 using Microsoft.Azure.Functions.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
 using Serilog;
 
 [assembly: FunctionsStartup(typeof(AstroForm.Functions.Startup))]

--- a/src/Functions/SwaggerFunctions.cs
+++ b/src/Functions/SwaggerFunctions.cs
@@ -4,7 +4,7 @@ using Microsoft.Azure.WebJobs;
 using Microsoft.Azure.WebJobs.Extensions.Http;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.OpenApi.Models;
-using Swashbuckle.AspNetCore.SwaggerGen;
+using Swashbuckle.AspNetCore.Swagger;
 
 namespace AstroForm.Functions;
 

--- a/src/Functions/UserFunctions.cs
+++ b/src/Functions/UserFunctions.cs
@@ -20,7 +20,7 @@ public class UserFunctions
     public async Task<IActionResult> RegisterUser(
         [HttpTrigger(AuthorizationLevel.Function, "post", Route = "users/register")] HttpRequest req)
     {
-        var data = await req.ReadFromJsonAsync<UserRegistration>() ?? new UserRegistration();
+        var data = await req.ReadFromJsonAsync<UserRegistration>() ?? new UserRegistration(string.Empty, string.Empty, string.Empty, DateTime.MinValue);
         var user = await _service.RegisterAsync(data.Id, data.DisplayName, data.Email, data.ConsentGivenAt);
         return new OkObjectResult(user);
     }
@@ -30,7 +30,7 @@ public class UserFunctions
         [HttpTrigger(AuthorizationLevel.Function, "post", Route = "users/{id}/role")] HttpRequest req,
         string id)
     {
-        var update = await req.ReadFromJsonAsync<RoleUpdate>() ?? new RoleUpdate();
+        var update = await req.ReadFromJsonAsync<RoleUpdate>() ?? new RoleUpdate(UserRole.Assistant);
         await _service.UpdateRoleAsync(id, update.Role);
         return new OkResult();
     }


### PR DESCRIPTION
## Summary
- switch Functions project to `Microsoft.NET.Sdk`
- add required package references and remove isolated worker setup
- delete obsolete `Program.cs`
- add `global.json` to specify SDK versions
- fix compile errors in Functions code

## Testing
- `dotnet restore src/AstroForm.sln`
- `dotnet build src/AstroForm.sln --configuration Release --no-restore`
- `dotnet test src/AstroForm.sln --configuration Release --collect:"XPlat Code Coverage" --results-directory TestResults --no-build`


------
https://chatgpt.com/codex/tasks/task_e_68564d9c849c8320b7f4d6194fabd47c