### PR TITLE
Add preview cleanup and management features

### DIFF
--- a/src/Api/Program.cs
+++ b/src/Api/Program.cs
@@ -124,6 +124,12 @@ app.MapPost("/forms/{id}/preview", async (Guid id, Form form, FormPublishService
     return Results.Ok(new { path });
 });
 
+app.MapDelete("/forms/{id}/preview", async (Guid id, FormPublishService publisher) =>
+{
+    await publisher.DeletePreviewAsync(id);
+    return Results.Ok();
+});
+
 app.MapPost("/forms/{id}/publish", async (Guid id, Form form, IFormRepository repo, FormPublishService publisher, ActivityLogService logs) =>
 {
     form.Id = id;
@@ -178,6 +184,18 @@ app.MapPost("/users/register", async (UserRegistration req, ClaimsPrincipal prin
 app.MapPost("/users/{id}/role", async (string id, RoleUpdate req, UserService service) =>
 {
     await service.UpdateRoleAsync(id, req.Role);
+    return Results.Ok();
+});
+
+app.MapDelete("/users/{id}", async (string id, UserService service, IFormRepository forms) =>
+{
+    await service.DeleteUserAsync(id, forms);
+    return Results.Ok();
+});
+
+app.MapDelete("/users/{id}/forms", async (string id, IFormRepository forms) =>
+{
+    await forms.DeleteFormsByUserAsync(id);
     return Results.Ok();
 });
 

--- a/src/Application.Tests/FormPublishServiceTests.cs
+++ b/src/Application.Tests/FormPublishServiceTests.cs
@@ -72,5 +72,19 @@ namespace AstroForm.Tests
             Assert.False(File.Exists(path));
             Assert.Equal(FormStatus.Draft, form.Status);
         }
+
+        [Fact]
+        public async Task DeletePreview_RemovesFile()
+        {
+            var previewDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+            var service = new FormPublishService("unused", previewDir);
+            var form = CreateSampleForm();
+
+            var path = await service.GeneratePreviewAsync(form);
+            Assert.True(File.Exists(path));
+
+            await service.DeletePreviewAsync(form.Id);
+            Assert.False(File.Exists(path));
+        }
     }
 }

--- a/src/Application/FormEditorService.cs
+++ b/src/Application/FormEditorService.cs
@@ -138,9 +138,9 @@ namespace AstroForm.Application
                 new FormItem { Id = Guid.NewGuid(), FormId = formId, Type = "email", Label = "メールアドレス", DisplayOrder = 3, IsDefault = true },
                 new FormItem { Id = Guid.NewGuid(), FormId = formId, Type = "date", Label = "生まれた年・月・日", DisplayOrder = 4, IsDefault = true },
                 new FormItem { Id = Guid.NewGuid(), FormId = formId, Type = "time", Label = "生まれた時・分", DisplayOrder = 5, IsDefault = true },
-                new FormItem { Id = Guid.NewGuid(), FormId = formId, Type = "text", Label = "生まれた国", DisplayOrder = 6, IsDefault = true },
-                new FormItem { Id = Guid.NewGuid(), FormId = formId, Type = "text", Label = "生まれた都道府県", DisplayOrder = 7, IsDefault = true },
-                new FormItem { Id = Guid.NewGuid(), FormId = formId, Type = "text", Label = "生まれた市町村", DisplayOrder = 8, IsDefault = true }
+                new FormItem { Id = Guid.NewGuid(), FormId = formId, Type = "place", Label = "生まれた国", DisplayOrder = 6, IsDefault = true },
+                new FormItem { Id = Guid.NewGuid(), FormId = formId, Type = "place", Label = "生まれた都道府県", DisplayOrder = 7, IsDefault = true },
+                new FormItem { Id = Guid.NewGuid(), FormId = formId, Type = "place", Label = "生まれた市町村", DisplayOrder = 8, IsDefault = true }
             };
         }
 

--- a/src/Application/UserService.cs
+++ b/src/Application/UserService.cs
@@ -39,5 +39,11 @@ namespace AstroForm.Application
             user.UpdatedAt = DateTime.UtcNow;
             await _repository.SaveAsync(user);
         }
+
+        public async Task DeleteUserAsync(string id, IFormRepository forms)
+        {
+            await _repository.DeleteAsync(id);
+            await forms.DeleteFormsByUserAsync(id);
+        }
     }
 }

--- a/src/Domain/IFormRepository.cs
+++ b/src/Domain/IFormRepository.cs
@@ -12,5 +12,6 @@ namespace AstroForm.Domain.Repositories
         Task DeleteFormAsync(Guid id);
         Task<IReadOnlyList<FormSubmission>> GetSubmissionsAsync(Guid formId);
         Task DeleteSubmissionAsync(Guid formId, Guid submissionId);
+        Task DeleteFormsByUserAsync(string userId);
     }
 }

--- a/src/Domain/IUserRepository.cs
+++ b/src/Domain/IUserRepository.cs
@@ -7,5 +7,6 @@ namespace AstroForm.Domain.Repositories
     {
         Task<User?> GetByIdAsync(string id);
         Task SaveAsync(User user);
+        Task DeleteAsync(string id);
     }
 }

--- a/src/Functions/DataPurgeFunctions.cs
+++ b/src/Functions/DataPurgeFunctions.cs
@@ -1,0 +1,31 @@
+using AstroForm.Application;
+using AstroForm.Domain.Repositories;
+using Microsoft.Azure.WebJobs;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Threading.Tasks;
+
+namespace AstroForm.Functions;
+
+public class DataPurgeFunctions
+{
+    private readonly IFormRepository _repository;
+    private readonly FormAnswerService _answerService;
+
+    public DataPurgeFunctions(IFormRepository repository, FormAnswerService answerService)
+    {
+        _repository = repository;
+        _answerService = answerService;
+    }
+
+    [FunctionName("PurgeOldSubmissions")]
+    public async Task PurgeOldSubmissions([TimerTrigger("0 0 0 * * *")]TimerInfo timer, ILogger logger)
+    {
+        var forms = await _repository.GetAllAsync();
+        foreach (var form in forms)
+        {
+            await _answerService.PurgeOldSubmissionsAsync(form.Id, TimeSpan.FromDays(30));
+        }
+        logger.LogInformation("Old submissions purged");
+    }
+}

--- a/src/Functions/FormFunctions.cs
+++ b/src/Functions/FormFunctions.cs
@@ -153,6 +153,19 @@ public class FormFunctions
         return new OkObjectResult(new { path });
     }
 
+    [FunctionName("DeletePreview")]
+    public async Task<IActionResult> DeletePreview(
+        [HttpTrigger(AuthorizationLevel.Function, "delete", Route = "forms/{id}/preview")] HttpRequest req,
+        string id)
+    {
+        if (!Guid.TryParse(id, out var guid))
+        {
+            return new BadRequestResult();
+        }
+        await _publisher.DeletePreviewAsync(guid);
+        return new OkResult();
+    }
+
     [FunctionName("PublishForm")]
     public async Task<IActionResult> PublishForm(
         [HttpTrigger(AuthorizationLevel.Function, "post", Route = "forms/{id}/publish")] HttpRequest req,

--- a/src/Functions/UserFunctions.cs
+++ b/src/Functions/UserFunctions.cs
@@ -1,5 +1,6 @@
 using AstroForm.Application;
 using AstroForm.Domain.Entities;
+using AstroForm.Domain.Repositories;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Azure.WebJobs;
@@ -10,10 +11,12 @@ namespace AstroForm.Functions;
 public class UserFunctions
 {
     private readonly UserService _service;
+    private readonly IFormRepository _forms;
 
-    public UserFunctions(UserService service)
+    public UserFunctions(UserService service, IFormRepository forms)
     {
         _service = service;
+        _forms = forms;
     }
 
     [FunctionName("RegisterUser")]
@@ -32,6 +35,15 @@ public class UserFunctions
     {
         var update = await req.ReadFromJsonAsync<RoleUpdate>() ?? new RoleUpdate(UserRole.Assistant);
         await _service.UpdateRoleAsync(id, update.Role);
+        return new OkResult();
+    }
+
+    [FunctionName("DeleteUser")]
+    public async Task<IActionResult> DeleteUser(
+        [HttpTrigger(AuthorizationLevel.Function, "delete", Route = "users/{id}")] HttpRequest req,
+        string id)
+    {
+        await _service.DeleteUserAsync(id, _forms);
         return new OkResult();
     }
 

--- a/src/Infra/EncryptedFormRepository.cs
+++ b/src/Infra/EncryptedFormRepository.cs
@@ -85,5 +85,10 @@ namespace AstroForm.Infra
         {
             return _inner.DeleteFormAsync(id);
         }
+
+        public Task DeleteFormsByUserAsync(string userId)
+        {
+            return _inner.DeleteFormsByUserAsync(userId);
+        }
     }
 }

--- a/src/Infra/InMemoryFormRepository.cs
+++ b/src/Infra/InMemoryFormRepository.cs
@@ -56,5 +56,14 @@ namespace AstroForm.Infra
             }
             return Task.CompletedTask;
         }
+
+        public Task DeleteFormsByUserAsync(string userId)
+        {
+            foreach (var form in _store.Values.Where(f => f.UserId == userId).ToList())
+            {
+                _store.TryRemove(form.Id, out _);
+            }
+            return Task.CompletedTask;
+        }
     }
 }

--- a/src/Infra/InMemoryUserRepository.cs
+++ b/src/Infra/InMemoryUserRepository.cs
@@ -20,5 +20,11 @@ namespace AstroForm.Infra
             _store[user.Id] = user;
             return Task.CompletedTask;
         }
+
+        public Task DeleteAsync(string id)
+        {
+            _store.TryRemove(id, out _);
+            return Task.CompletedTask;
+        }
     }
 }

--- a/src/Presentation.Client/Components/DatePickerField.razor
+++ b/src/Presentation.Client/Components/DatePickerField.razor
@@ -1,1 +1,9 @@
-<input type="date" class="date-picker" />
+<input type="date" @bind="Value" class="date-picker" />
+
+@code {
+    [Parameter]
+    public DateTime? Value { get; set; }
+
+    [Parameter]
+    public EventCallback<DateTime?> ValueChanged { get; set; }
+}

--- a/src/Presentation.Client/Components/FormList.razor
+++ b/src/Presentation.Client/Components/FormList.razor
@@ -11,7 +11,7 @@
         {
             @foreach (var form in _forms)
             {
-                <FormListItem Form="form" />
+                <FormListItem Form="form" OnChanged="Load" />
             }
         }
     </ul>
@@ -24,6 +24,12 @@
 
     protected override async Task OnInitializedAsync()
     {
+        await Load();
+    }
+
+    private async Task Load()
+    {
         _forms = await Repository.GetAllAsync();
+        StateHasChanged();
     }
 }

--- a/src/Presentation.Client/Components/FormListItem.razor
+++ b/src/Presentation.Client/Components/FormListItem.razor
@@ -1,8 +1,44 @@
 @using AstroForm.Domain.Entities
 
-<li class="form-list-item">@Form.Name</li>
+<li class="form-list-item">
+    <span>@Form.Name (@Form.Status)</span>
+    <a href="/form-editor?id=@Form.Id">Edit</a>
+    <button @onclick="Delete">Delete</button>
+    @if (Form.Status == FormStatus.Draft)
+    {
+        <button @onclick="Publish">Publish</button>
+    }
+    else
+    {
+        <button @onclick="Unpublish">Unpublish</button>
+    }
+</li>
 
 @code {
     [Parameter]
     public Form Form { get; set; } = default!;
+    [Parameter]
+    public EventCallback OnChanged { get; set; }
+
+    [Inject] public HttpClient Http { get; set; } = default!;
+
+    private async Task Publish()
+    {
+        await Http.PostAsJsonAsync($"forms/{Form.Id}/publish", Form);
+        Form.Status = FormStatus.Published;
+        await OnChanged.InvokeAsync();
+    }
+
+    private async Task Unpublish()
+    {
+        await Http.PostAsync($"forms/{Form.Id}/draft", null);
+        Form.Status = FormStatus.Draft;
+        await OnChanged.InvokeAsync();
+    }
+
+    private async Task Delete()
+    {
+        await Http.DeleteAsync($"forms/{Form.Id}");
+        await OnChanged.InvokeAsync();
+    }
 }

--- a/src/Presentation.Client/Components/FormPreview.razor
+++ b/src/Presentation.Client/Components/FormPreview.razor
@@ -1,3 +1,4 @@
+@implements IAsyncDisposable
 <div class="form-preview">
     @if (_previewPath is null)
     {
@@ -20,6 +21,14 @@
         var response = await Http.PostAsJsonAsync($"forms/{Service.CurrentForm.Id}/preview", Service.CurrentForm);
         var result = await response.Content.ReadFromJsonAsync<PreviewResponse>();
         _previewPath = result?.Path;
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_previewPath is not null)
+        {
+            await Http.DeleteAsync($"forms/{Service.CurrentForm.Id}/preview");
+        }
     }
 
     private record PreviewResponse(string Path);

--- a/src/Presentation.Client/Components/PlaceAutocomplete.razor
+++ b/src/Presentation.Client/Components/PlaceAutocomplete.razor
@@ -1,1 +1,27 @@
-<input placeholder="Enter location" class="place-autocomplete" />
+@implements IAsyncDisposable
+<input id="@_id" placeholder="Enter location" @bind="Value" class="place-autocomplete" />
+
+@code {
+    [Parameter]
+    public string? Value { get; set; }
+
+    [Parameter]
+    public EventCallback<string?> ValueChanged { get; set; }
+
+    [Inject] IJSRuntime JS { get; set; } = default!;
+
+    private readonly string _id = $"p_{Guid.NewGuid()}";
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (firstRender)
+        {
+            await JS.InvokeVoidAsync("initPlaceAutocomplete", _id);
+        }
+    }
+
+    public ValueTask DisposeAsync()
+    {
+        return JS.InvokeVoidAsync("disposePlaceAutocomplete", _id);
+    }
+}

--- a/src/Presentation.Client/Components/TimePickerField.razor
+++ b/src/Presentation.Client/Components/TimePickerField.razor
@@ -1,1 +1,9 @@
-<input type="time" class="time-picker" />
+<input type="time" @bind="Value" class="time-picker" />
+
+@code {
+    [Parameter]
+    public TimeSpan? Value { get; set; }
+
+    [Parameter]
+    public EventCallback<TimeSpan?> ValueChanged { get; set; }
+}

--- a/src/Presentation.Client/Services/HttpFormRepository.cs
+++ b/src/Presentation.Client/Services/HttpFormRepository.cs
@@ -46,4 +46,9 @@ public class HttpFormRepository : IFormRepository
     {
         await _http.DeleteAsync($"forms/{formId}/answers/{submissionId}");
     }
+
+    public async Task DeleteFormsByUserAsync(string userId)
+    {
+        await _http.DeleteAsync($"users/{userId}/forms");
+    }
 }

--- a/src/Presentation.Client/wwwroot/index.html
+++ b/src/Presentation.Client/wwwroot/index.html
@@ -26,6 +26,7 @@
         <a href="" class="reload">Reload</a>
         <a class="dismiss">🗙</a>
     </div>
+    <script src="scripts.js"></script>
     <script src="_framework/blazor.webassembly.js"></script>
 </body>
 

--- a/src/Presentation.Client/wwwroot/scripts.js
+++ b/src/Presentation.Client/wwwroot/scripts.js
@@ -1,0 +1,16 @@
+window.initPlaceAutocomplete = function(id){
+    if (!window.google || !google.maps || !google.maps.places){
+        return;
+    }
+    var input = document.getElementById(id);
+    if(input){
+        input._autocomplete = new google.maps.places.Autocomplete(input);
+    }
+}
+window.disposePlaceAutocomplete = function(id){
+    var input = document.getElementById(id);
+    if(input && input._autocomplete){
+        google.maps.event.clearInstanceListeners(input._autocomplete);
+        delete input._autocomplete;
+    }
+}


### PR DESCRIPTION
## Summary
- clean up preview HTML after use
- add form management controls and actions
- implement date/time pickers and Google Places autocomplete
- add GDPR data purge timer job and user data deletion endpoints
- update tests for new preview cleanup

## Testing
- `dotnet test src/AstroForm.sln`

------
https://chatgpt.com/codex/tasks/task_e_68565bf3a8a4832088eb587c061d5992