### PR TITLE
Implement autosave blur, cosmos repo and external ID stubs

### DIFF
--- a/src/Api/Api.csproj
+++ b/src/Api/Api.csproj
@@ -12,6 +12,8 @@
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.2" />
     <PackageReference Include="Serilog.AspNetCore" Version="8.0.1" />
   </ItemGroup>
+  <ItemGroup>
+  </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\Application\Application.csproj" />

--- a/src/Application.Tests/SmokeTests.cs
+++ b/src/Application.Tests/SmokeTests.cs
@@ -2,11 +2,10 @@ using AstroForm.Application;
 using AstroForm.Domain.Repositories;
 using AstroForm.Domain.Services;
 using AstroForm.Infra;
-using Microsoft.Extensions.DependencyInjection;
 using Xunit;
-
+using Microsoft.Extensions.DependencyInjection;
+using AstroForm.Domain.Entities;
 namespace Application.Tests;
-
 public class SmokeTests
 {
     [Fact]
@@ -17,6 +16,7 @@ public class SmokeTests
         services.AddSingleton<IActivityLogRepository, InMemoryActivityLogRepository>();
         services.AddSingleton<IUserRepository, InMemoryUserRepository>();
         services.AddSingleton<IEmailService, InMemoryEmailService>();
+        services.AddSingleton<IExternalIdentityService, StubExternalId>();
         services.AddSingleton(sp => new FormPublishService("/tmp/public", "/tmp/preview"));
         services.AddSingleton<FormAnswerService>();
         services.AddSingleton<ActivityLogService>();
@@ -28,5 +28,12 @@ public class SmokeTests
         Assert.NotNull(provider.GetService<UserService>());
         Assert.NotNull(provider.GetService<ActivityLogService>());
         Assert.NotNull(provider.GetService<FormPublishService>());
+    }
+
+    private class StubExternalId : IExternalIdentityService
+    {
+        public Task CreateUserAsync(string id, string displayName, string email) => Task.CompletedTask;
+        public Task DeleteUserAsync(string id) => Task.CompletedTask;
+        public Task UpdateUserRoleAsync(string id, UserRole role) => Task.CompletedTask;
     }
 }

--- a/src/Application.Tests/UserServiceTests.cs
+++ b/src/Application.Tests/UserServiceTests.cs
@@ -4,6 +4,7 @@ using AstroForm.Domain.Entities;
 using AstroForm.Infra;
 using Xunit;
 
+using AstroForm.Domain.Services;
 namespace AstroForm.Tests
 {
     public class UserServiceTests
@@ -12,7 +13,7 @@ namespace AstroForm.Tests
         public async Task RegisterAndUpdateRole_Works()
         {
             var repo = new InMemoryUserRepository();
-            var service = new UserService(repo);
+            var service = new UserService(repo, new StubExternalId());
 
             var user = await service.RegisterAsync("u1", "test", "t@example.com", DateTime.UtcNow);
             Assert.Equal(UserRole.FortuneTeller, user.Role);
@@ -20,6 +21,13 @@ namespace AstroForm.Tests
             await service.UpdateRoleAsync("u1", UserRole.Admin);
             var updated = await service.GetByIdAsync("u1");
             Assert.Equal(UserRole.Admin, updated?.Role);
+        }
+
+        private class StubExternalId : IExternalIdentityService
+        {
+            public Task CreateUserAsync(string id, string displayName, string email) => Task.CompletedTask;
+            public Task DeleteUserAsync(string id) => Task.CompletedTask;
+            public Task UpdateUserRoleAsync(string id, UserRole role) => Task.CompletedTask;
         }
     }
 }

--- a/src/Application/GdprService.cs
+++ b/src/Application/GdprService.cs
@@ -1,0 +1,32 @@
+using System.Collections.Concurrent;
+using System.Threading.Tasks;
+using AstroForm.Domain.Repositories;
+
+namespace AstroForm.Application;
+
+public class GdprService
+{
+    private readonly ConcurrentQueue<string> _deleteQueue = new();
+    private readonly IUserRepository _users;
+    private readonly IFormRepository _forms;
+
+    public GdprService(IUserRepository users, IFormRepository forms)
+    {
+        _users = users;
+        _forms = forms;
+    }
+
+    public void RequestUserDeletion(string userId)
+    {
+        _deleteQueue.Enqueue(userId);
+    }
+
+    public async Task ProcessDeletionQueueAsync()
+    {
+        while (_deleteQueue.TryDequeue(out var id))
+        {
+            await _users.DeleteAsync(id);
+            await _forms.DeleteFormsByUserAsync(id);
+        }
+    }
+}

--- a/src/Domain/IExternalIdentityService.cs
+++ b/src/Domain/IExternalIdentityService.cs
@@ -1,0 +1,11 @@
+namespace AstroForm.Domain.Services;
+
+using System.Threading.Tasks;
+using AstroForm.Domain.Entities;
+
+public interface IExternalIdentityService
+{
+    Task CreateUserAsync(string id, string displayName, string email);
+    Task UpdateUserRoleAsync(string id, UserRole role);
+    Task DeleteUserAsync(string id);
+}

--- a/src/Functions/Functions.csproj
+++ b/src/Functions/Functions.csproj
@@ -17,6 +17,9 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="8.0.0" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.39.0" />
+  </ItemGroup>
+  <ItemGroup>
     <ProjectReference Include="..\Domain\Domain.csproj" />
     <ProjectReference Include="..\Application\Application.csproj" />
     <ProjectReference Include="..\Infra\Infra.csproj" />

--- a/src/Functions/GdprFunctions.cs
+++ b/src/Functions/GdprFunctions.cs
@@ -1,0 +1,34 @@
+using System.Threading.Tasks;
+using AstroForm.Application;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Azure.WebJobs;
+using Microsoft.Azure.WebJobs.Extensions.Http;
+
+namespace AstroForm.Functions;
+
+public class GdprFunctions
+{
+    private readonly GdprService _service;
+
+    public GdprFunctions(GdprService service)
+    {
+        _service = service;
+    }
+
+    [FunctionName("RequestUserDeletion")]
+    public IActionResult RequestUserDeletion(
+        [HttpTrigger(AuthorizationLevel.Function, "post", Route = "gdpr/delete/{id}")] HttpRequest req,
+        string id)
+    {
+        _service.RequestUserDeletion(id);
+        return new OkResult();
+    }
+
+    [FunctionName("ProcessDeletionRequests")]
+    public async Task ProcessDeletionRequests([
+        TimerTrigger("0 */5 * * * *")] TimerInfo timer)
+    {
+        await _service.ProcessDeletionQueueAsync();
+    }
+}

--- a/src/Infra/CosmosFormRepository.cs
+++ b/src/Infra/CosmosFormRepository.cs
@@ -1,0 +1,94 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Threading.Tasks;
+using AstroForm.Domain.Entities;
+using AstroForm.Domain.Repositories;
+using Microsoft.Azure.Cosmos;
+using Microsoft.Azure.Cosmos.Linq;
+
+namespace AstroForm.Infra;
+
+public class CosmosFormRepository : IFormRepository
+{
+    private readonly Container _forms;
+    private readonly Container _submissions;
+
+    public CosmosFormRepository(CosmosClient client, string database)
+    {
+        var db = client.GetDatabase(database);
+        _forms = db.GetContainer("Forms");
+        _submissions = db.GetContainer("FormSubmissions");
+    }
+
+    public async Task<IReadOnlyList<Form>> GetAllAsync()
+    {
+        var query = _forms.GetItemLinqQueryable<Form>().ToFeedIterator();
+        var list = new List<Form>();
+        while (query.HasMoreResults)
+        {
+            foreach (var item in await query.ReadNextAsync())
+            {
+                list.Add(item);
+            }
+        }
+        return list;
+    }
+
+    public async Task<Form?> GetByIdAsync(Guid id)
+    {
+        try
+        {
+            var resp = await _forms.ReadItemAsync<Form>(id.ToString(), new PartitionKey(id.ToString()));
+            return resp.Resource;
+        }
+        catch (CosmosException ex) when (ex.StatusCode == HttpStatusCode.NotFound)
+        {
+            return null;
+        }
+    }
+
+    public async Task SaveAsync(Form form)
+    {
+        await _forms.UpsertItemAsync(form, new PartitionKey(form.Id.ToString()));
+    }
+
+    public async Task DeleteFormAsync(Guid id)
+    {
+        await _forms.DeleteItemAsync<Form>(id.ToString(), new PartitionKey(id.ToString()));
+    }
+
+    public async Task<IReadOnlyList<FormSubmission>> GetSubmissionsAsync(Guid formId)
+    {
+        var query = _submissions.GetItemLinqQueryable<FormSubmission>()
+            .Where(s => s.FormId == formId)
+            .ToFeedIterator();
+        var list = new List<FormSubmission>();
+        while (query.HasMoreResults)
+        {
+            foreach (var item in await query.ReadNextAsync())
+            {
+                list.Add(item);
+            }
+        }
+        return list;
+    }
+
+    public async Task DeleteSubmissionAsync(Guid formId, Guid submissionId)
+    {
+        await _submissions.DeleteItemAsync<FormSubmission>(submissionId.ToString(), new PartitionKey(formId.ToString()));
+    }
+
+    public async Task DeleteFormsByUserAsync(string userId)
+    {
+        var query = _forms.GetItemLinqQueryable<Form>().Where(f => f.UserId == userId).ToFeedIterator();
+        while (query.HasMoreResults)
+        {
+            foreach (var item in await query.ReadNextAsync())
+            {
+                await DeleteFormAsync(item.Id);
+            }
+        }
+    }
+}

--- a/src/Infra/EntraExternalIdentityService.cs
+++ b/src/Infra/EntraExternalIdentityService.cs
@@ -1,0 +1,34 @@
+using System.Threading.Tasks;
+using AstroForm.Domain.Entities;
+using AstroForm.Domain.Services;
+using Microsoft.Extensions.Logging;
+
+namespace AstroForm.Infra;
+
+public class EntraExternalIdentityService : IExternalIdentityService
+{
+    private readonly ILogger<EntraExternalIdentityService> _logger;
+
+    public EntraExternalIdentityService(ILogger<EntraExternalIdentityService> logger)
+    {
+        _logger = logger;
+    }
+
+    public async Task CreateUserAsync(string id, string displayName, string email)
+    {
+        _logger.LogInformation("Create user {Id} {Email}", id, email);
+        await Task.CompletedTask;
+    }
+
+    public async Task UpdateUserRoleAsync(string id, UserRole role)
+    {
+        _logger.LogInformation("Update role of {Id} to {Role}", id, role);
+        await Task.CompletedTask;
+    }
+
+    public Task DeleteUserAsync(string id)
+    {
+        _logger.LogInformation("Delete user {Id}", id);
+        return Task.CompletedTask;
+    }
+}

--- a/src/Infra/Infra.csproj
+++ b/src/Infra/Infra.csproj
@@ -9,5 +9,10 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.39.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
+    <PackageReference Include="Azure.Identity" Version="1.10.4" />
+  </ItemGroup>
 
 </Project>

--- a/src/Presentation.Client/Components/FormEditor.razor
+++ b/src/Presentation.Client/Components/FormEditor.razor
@@ -3,8 +3,8 @@
         @foreach (var item in Service.CurrentForm.FormItems.OrderBy(i => i.DisplayOrder))
         {
             <li>
-                <input value="@item.Label" @onchange="e => OnEdit(item.Id, e.Value?.ToString() ?? string.Empty, item.Placeholder)" />
-                <input value="@item.Placeholder" @onchange="e => OnEdit(item.Id, item.Label, e.Value?.ToString())" />
+                <input value="@item.Label" @onchange="e => OnEdit(item.Id, e.Value?.ToString() ?? string.Empty, item.Placeholder)" @onblur="() => OnBlur()" />
+                <input value="@item.Placeholder" @onchange="e => OnEdit(item.Id, item.Label, e.Value?.ToString())" @onblur="() => OnBlur()" />
                 @if (!item.IsDefault)
                 {
                     <button @onclick="() => Remove(item.Id)">Delete</button>
@@ -31,5 +31,10 @@
     private void OnEdit(Guid id, string label, string? placeholder)
     {
         Service.UpdateItem(id, label, placeholder);
+    }
+
+    private async Task OnBlur()
+    {
+        await Service.BlurAsync();
     }
 }


### PR DESCRIPTION
## Summary
- add `IExternalIdentityService` interface and `EntraExternalIdentityService` stub
- create `CosmosFormRepository` for persistence
- implement GDPR deletion service and Azure Functions
- trigger save on input blur in form editor
- integrate new services via DI and add GDPR delete endpoint
- update tests for new dependencies

## Testing
- `dotnet test src/AstroForm.sln`

------
https://chatgpt.com/codex/tasks/task_e_6856630dd38c8320a99006dd45cad142